### PR TITLE
Change external-database port to template

### DIFF
--- a/samples/ra-vpn/redirector-lb/ravpn-enforcer-config.yaml
+++ b/samples/ra-vpn/redirector-lb/ravpn-enforcer-config.yaml
@@ -71,11 +71,11 @@ spec:
     # Configure Redis server IP and enable external database.
     external-database
       host {{ index .secrets "sfcn-redis" "host" }}
-      port 6379
+      port {{ index .secrets "sfcn-redis" "port" }}
       # this should match the token used for elasticache creation (EnforcerCacheAuthToken). If you omitted that field, then
       # you should also omit the `db-password` line below.
       db-password {{ index .secrets "sfcn-redis" "token" }}
-     enable
+      enable
     
     # Any priority value other than 10 designates the ASAc
     # as a member.

--- a/samples/ra-vpn/redirector-lb/ravpn-redirector-config.yaml
+++ b/samples/ra-vpn/redirector-lb/ravpn-redirector-config.yaml
@@ -37,7 +37,7 @@ spec:
     
     external-database
       host {{ index .secrets "sfcn-redis" "host" }}
-      port 6379
+      port {{ index .secrets "sfcn-redis" "port" }}
       # this should match the token used for elasticache creation (EnforcerCacheAuthToken). If you omitted that field, then
       # you should also omit the `db-password` line below.
       db-password {{ index .secrets "sfcn-redis" "token" }}

--- a/samples/ra-vpn/saml-multi-region/enforcers-asaconf.yaml
+++ b/samples/ra-vpn/saml-multi-region/enforcers-asaconf.yaml
@@ -89,12 +89,12 @@ spec:
       nat {{ index .nodeLabels "sfcn.cisco.com.interface.2/public-ip" }}
     vpn-sessiondb external-database
     external-database
-     host {{ index .secrets "sfcn-redis" "host" }}
-     port 6379
+      host {{ index .secrets "sfcn-redis" "host" }}
+      port {{ index .secrets "sfcn-redis" "port" }}
       # this should match the token used for elasticache creation (EnforcerCacheAuthToken). If you omitted that field, then
       # you should also omit the `db-password` line below.
       db-password {{ index .secrets "sfcn-redis" "token" }}
-     enable
+      enable
 
     webvpn
       enable outside

--- a/samples/ra-vpn/saml-multi-region/redirector-asaconf.yaml
+++ b/samples/ra-vpn/saml-multi-region/redirector-asaconf.yaml
@@ -70,12 +70,12 @@ spec:
       nat {{ index .nodeLabels "sfcn.cisco.com.interface.2/public-ip" }}
     vpn-sessiondb external-database
     external-database
-     host {{ index .secrets "sfcn-redis" "host" }}
-     port 6379
+      host {{ index .secrets "sfcn-redis" "host" }}
+      port {{ index .secrets "sfcn-redis" "port" }}
       # this should match the token used for elasticache creation (EnforcerCacheAuthToken). If you omitted that field, then
       # you should also omit the `db-password` line below.
       db-password {{ index .secrets "sfcn-redis" "token" }}
-     enable
+      enable
     webvpn
       enable outside
 


### PR DESCRIPTION
Change the external-database to get the information from sfcn-redis secret, instead of hardcoding it